### PR TITLE
Fix incorrect dynamic array creation

### DIFF
--- a/vkb/device_builder.odin
+++ b/vkb/device_builder.odin
@@ -1,9 +1,9 @@
 package vk_bootstrap
 
 // Core
+import "base:runtime"
 import "core:log"
 import "core:mem"
-import "base:runtime"
 import "core:slice"
 
 // Vendor
@@ -93,6 +93,7 @@ build_device :: proc(self: ^Device_Builder) -> (device: ^Device, err: Error) {
 	// Enable all supported device extensions
 	extensions_to_enable := make(
 		[dynamic]cstring,
+		0,
 		len(self.physical_device.extensions_to_enable),
 		context.temp_allocator,
 	) or_return


### PR DESCRIPTION
The extensions_to_enable array in the build_device procedure was being created with a capacity *and* length equal to the size of the physical device's extensions_to_enable array, before having said array appended to it. this has the nasty size effect of effectively doubling the array's size and filling it with empty strings.

This PR fixes that by specifying the length in the make call.