### PR TITLE
Fix checking required extensions when selecting device

### DIFF
--- a/vkb/physical_device_utils.odin
+++ b/vkb/physical_device_utils.odin
@@ -19,13 +19,14 @@ check_device_extension_support :: proc(
 		return true
 	}
 
-	for &avail_ext in available_extensions {
-		for req_ext in required_extensions {
-			if cstring(&avail_ext.extensionName[0]) != req_ext {
-				log.warnf("Required extension \x1b[33m%s\x1b[0m is not available", req_ext)
-				supported = false
+	required_loop: for req_ext in required_extensions {
+		for &avail_ext in available_extensions {
+			if cstring(&avail_ext.extensionName[0]) == req_ext {
+				continue required_loop
 			}
 		}
+		log.warnf("Required extension \x1b[33m%s\x1b[0m is not available", req_ext)
+		supported = false
 	}
 
 	return


### PR DESCRIPTION
The original code had a logic error when verifying required extensions. For each required extension, it would check against each available extension, but the supported = false flag was being set if any single comparison didn't match. This meant that even if a required extension existed in the available extensions list, the code would still mark it as unsupported if it wasn't the first item in the list.

The new implementation properly:

- Uses a labeled loop approach with required_loop
- Continues to the next required extension once a match is found
- Only marks an extension as unsupported if it has gone through the entire available extensions list without finding a match