### PR TITLE
fix: add global context feature

### DIFF
--- a/vkb/init_vulkan.odin
+++ b/vkb/init_vulkan.odin
@@ -1,4 +1,5 @@
 #+vet !unused-imports
+#+feature global-context
 package vk_bootstrap
 
 // Core

--- a/vkb/init_vulkan.odin
+++ b/vkb/init_vulkan.odin
@@ -1,5 +1,4 @@
 #+vet !unused-imports
-#+feature global-context
 package vk_bootstrap
 
 // Core
@@ -14,7 +13,9 @@ import vk "vendor:vulkan"
 g_module: dynlib.Library = nil
 
 @(init, private = "file")
-init :: proc() {
+init :: proc "contextless" () {
+	context = runtime.default_context()
+
 	loaded: bool
 
 	// Load Vulkan library by platform
@@ -67,6 +68,7 @@ init :: proc() {
 }
 
 @(fini, private = "file")
-deinit :: proc() {
+deinit :: proc "contextless" () {
+	context = runtime.default_context()
 	dynlib.unload_library(g_module)
 }


### PR DESCRIPTION
A recent change to the Odin compiler adds a stricter check that detects when @init proceures use the global context. By setting the procedures to be `"contextless"` and setting the context to the runtime default inside the procedures, we can avoid any compiler errors.

An alternative is to add the flag `#+feature global-context` to the top of `init_vulkan.odin`, though the wording of the compiler errors makes me suspect that it would only be a temporary solution.